### PR TITLE
Exclude vault .hsm files from list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -15,7 +15,9 @@ list_all () {
   local v
 
   for v in $(curl -s "https://releases.hashicorp.com/${toolname}/" \
-        | awk -F'[<>]' "/<a href=.*${toolname}_/ {print \$3}"); do
+    | awk -F'[<>]' "/<a href=.*${toolname}_/ {print \$3}" \
+    | grep -v '\.hsm$')
+  do
     version="${v#${toolname}_}"
     if [[ -z "${versions}" ]]; then
       versions="${version}"


### PR DESCRIPTION
There ain't no darwin .hsm binaries, and I imagine folks that use those aren't discovering them via asdf, so just exclude them from that output (and by extension, travis tests).